### PR TITLE
Use POSIX test

### DIFF
--- a/launch-c.in
+++ b/launch-c.in
@@ -2,7 +2,7 @@
 
 # Xcode generator doesn't include the compiler as the
 # first argument, Ninja and Makefiles do. Handle both cases.
-if [[ "$1" = "${CMAKE_C_COMPILER}" ]] ; then
+if [ "$1" = "${CMAKE_C_COMPILER}" ] ; then
     shift
 fi
 

--- a/launch-cxx.in
+++ b/launch-cxx.in
@@ -2,7 +2,7 @@
 
 # Xcode generator doesn't include the compiler as the
 # first argument, Ninja and Makefiles do. Handle both cases.
-if [[ "$1" = "${CMAKE_CXX_COMPILER}" ]] ; then
+if [ "$1" = "${CMAKE_CXX_COMPILER}" ] ; then
     shift
 fi
 


### PR DESCRIPTION
Builds were broken on distros where `/bin/sh` is linked to a minimal, POSIX compliant shell e.g. Ubuntu.