### PR TITLE
Adds CMAKE_CURRENT_LIST_DIR prefix to config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ if (USE_CCACHE)
             set(CCCACHE_EXPORTS "${CCCACHE_EXPORTS}\nexport ${option}")
         endforeach()
 
-        configure_file(launch-c.in   launch-c)
-        configure_file(launch-cxx.in launch-cxx)
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/launch-c.in   launch-c)
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/launch-cxx.in launch-cxx)
 
         execute_process(COMMAND chmod a+rx
                         "${CMAKE_CURRENT_BINARY_DIR}/launch-c"


### PR DESCRIPTION
This commit allows the `CMakeLists.txt` file to be included by
projects without being incorporated directly into their main CMake
logic. One use case is to allow a consumer of this CMake project to
include it via the `CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE` CMake variable
by giving the path to the `CMakeLists.txt` file directly.

Fixes TheLartians/Ccache.cmake#1