### PR TITLE
add project() command to CMakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 cmake_minimum_required(VERSION 3.4)
 
+project(
+  CCache.cmake
+  LANGUAGES C CXX
+)
+
 option(USE_CCACHE "" OFF)
 set(CCACHE_OPTIONS "" CACHE STRING "options for ccache")
 


### PR DESCRIPTION
This allows us to properly set CCache for C and C++, even if the top-level parent project doesn't use both languages.

Fixes #6