### PR TITLE
Update test cmake version

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.14)
 
 project(main)
 


### PR DESCRIPTION
This updates the minimum CMake version in the tests as Support for [CMake < 3.5 has been removed in CMake 4](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features).