### PR TITLE
update example in readme to use version 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ Add the following lines to the project's `CMakeLists.txt` after calling `project
 ```CMake
 include(cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME Ccache.cmake
-  GITHUB_REPOSITORY TheLartians/Ccache.cmake
-  VERSION 1.2
-)
+CPMAddPackage("gh:TheLartians/Ccache.cmake@1.2.5")
 ```
 
 ### Using git submodules (not suited for libraries)


### PR DESCRIPTION
This PR updates the suggested version in the example to 1.2.5, as version 1.2 uses a deprecated minimum CMake version as noticed in #13.